### PR TITLE
Update weather.py

### DIFF
--- a/custom_components/astroweather/weather.py
+++ b/custom_components/astroweather/weather.py
@@ -305,7 +305,7 @@ class AstroWeatherWeather(AstroWeatherEntity, WeatherEntity):
     @property
     def native_temperature_unit(self) -> str:
         """Return the unit of measurement for temperature."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def humidity(self) -> int:

--- a/custom_components/astroweather/weather.py
+++ b/custom_components/astroweather/weather.py
@@ -21,7 +21,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.const import (
     CONF_ID,
-    TEMP_CELSIUS,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
 


### PR DESCRIPTION
fix deprication warning "TEMP_CELSIUS" with HA 2024.1.0b0

the PR is probably causing the follwing error:

```
Logger: homeassistant.components.weather
Source: helpers/entity_platform.py:368
Integration: Weather ([documentation](https://rc.home-assistant.io/integrations/weather), [issues](https://github.com/home-assistant/core/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+weather%22))
First occurred: 5:31:46 PM (1 occurrences)
Last logged: 5:31:46 PM

Error while setting up astroweather platform for weather
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 368, in _async_setup_platform
    await asyncio.gather(*pending)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 507, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 752, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1275, in add_to_platform_finish
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 938, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1059, in _async_write_ha_state
    state, attr, capabilities, shadowed_attr = self.__async_calculate_state()
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 998, in __async_calculate_state
    attr.update(self.state_attributes or {})
                ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/weather/__init__.py", line 686, in state_attributes
    from_unit = self.native_temperature_unit or self._default_temperature_unit
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/astroweather/weather.py", line 309, in native_temperature_unit
NameError: name 'TEMP_CELSIUS' is not defined
```
```
Logger: homeassistant.components.weather
Source: helpers/entity_platform.py:507
Integration: Weather ([documentation](https://rc.home-assistant.io/integrations/weather), [issues](https://github.com/home-assistant/core/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+weather%22))
First occurred: 5:31:46 PM (1 occurrences)
Last logged: 5:31:46 PM

Error adding entities for domain weather with platform astroweather
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 507, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 752, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1275, in add_to_platform_finish
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 938, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1059, in _async_write_ha_state
    state, attr, capabilities, shadowed_attr = self.__async_calculate_state()
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 998, in __async_calculate_state
    attr.update(self.state_attributes or {})
                ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/weather/__init__.py", line 686, in state_attributes
    from_unit = self.native_temperature_unit or self._default_temperature_unit
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/astroweather/weather.py", line 309, in native_temperature_unit
NameError: name 'TEMP_CELSIUS' is not defined
```
